### PR TITLE
[semver:patch] - Get last tag on export-tag command improvements for releases with different prefixes

### DIFF
--- a/src/scripts/export-tag.sh
+++ b/src/scripts/export-tag.sh
@@ -17,6 +17,8 @@ then
     LABEL="patch"
 fi
 
+echo "Try to get last tag using prefix: ${PREFIX}. If this is a new prefix, we will start from scratch."
+
 LAST_TAG=$(git describe --tags --abbrev=0 | grep -E "$PREFIX" | sed -e "s/^$PREFIX//")
 
 echo "Last Tag: $LAST_TAG"
@@ -33,16 +35,16 @@ function validate_version {
     local version=$1
     echo "Version to validate: $version"
     if [[ "$version" =~ $SEMVER_REGEX ]]; then
-    if [ "$#" -eq "2" ]; then
-        local major=${BASH_REMATCH[2]}
-        local minor=${BASH_REMATCH[3]}
-        local patch=${BASH_REMATCH[4]}
-        eval "$2=(\"$major\" \"$minor\" \"$patch\")"
+      if [ "$#" -eq "2" ]; then
+          local major=${BASH_REMATCH[2]}
+          local minor=${BASH_REMATCH[3]}
+          local patch=${BASH_REMATCH[4]}
+          eval "$2=(\"$major\" \"$minor\" \"$patch\")"
+      else
+          echo "$version"
+      fi
     else
-        echo "$version"
-    fi
-    else
-    error "version $version does not match the semver scheme 'X.Y.Z'. See help for more information."
+      error "version $version does not match the semver scheme 'X.Y.Z'. See help for more information."
     fi
 }
 
@@ -52,12 +54,15 @@ function increment {
 
     # If no last_tag was found, we start from scratch.
     if [ -z "$LAST_TAG" ]; then
+        echo "LAST_TAG is empty, build tag name using prefix (${PREFIX})."
         LAST_TAG="${PREFIX}0.0.0"
+        echo "New tag name built: ${LAST_TAG}".
     fi
 
     command=$LABEL
     version=$LAST_TAG
 
+    echo "Validating tag name..."
     validate_version "$version" parts
     # shellcheck disable=SC2154
     local major="${parts[0]}"

--- a/src/scripts/export-tag.sh
+++ b/src/scripts/export-tag.sh
@@ -12,7 +12,7 @@ PR_NUMBER=$(curl -s -X GET -u "$USER":"$GIT_USER_TOKEN" https://api.github.com/s
 
 LABEL=$(curl -s -X GET -u "$USER":"$GIT_USER_TOKEN" https://api.github.com/repos/"$REPO_ORG"/"$REPO_NAME"/issues/"$PR_NUMBER"/labels | jq .[0].name -r)
 
-if [ "$LABEL" = null ] || [ "$LABEL" = "WIP" ]; then
+if [ "$LABEL" == null ] || [ "$LABEL" == "WIP" ]; then
     LABEL="patch"
 fi
 

--- a/src/scripts/export-tag.sh
+++ b/src/scripts/export-tag.sh
@@ -19,8 +19,8 @@ fi
 
 LAST_TAG=$(git describe --tags --abbrev=0 | grep -E "$PREFIX" | sed -e "s/^$PREFIX//")
 
-echo "Last Tag: $LAST_TAG".
-echo "Semver part to update: $LABEL".
+echo "Last Tag: $LAST_TAG"
+echo "Semver part to update: $LABEL"
 
 # Show error message.
 function error {

--- a/src/scripts/export-tag.sh
+++ b/src/scripts/export-tag.sh
@@ -14,15 +14,14 @@ PR_NUMBER=$(curl -s -X GET -u "$USER":"$GIT_USER_TOKEN" https://api.github.com/s
 
 LABEL=$(curl -s -X GET -u "$USER":"$GIT_USER_TOKEN" https://api.github.com/repos/"$REPO_ORG"/"$REPO_NAME"/issues/"$PR_NUMBER"/labels | jq .[0].name -r)
 
-if [ "$LABEL" == null ] || [ "$LABEL" == "WIP" ]
-then
+if [ "$LABEL" = null ] || [ "$LABEL" = "WIP" ]; then
     LABEL="patch"
 fi
 
 echo "Try to get last tag using prefix: ${PREFIX}. If this is a new prefix, we will start from scratch."
-
-set -x
-LAST_TAG=$(git describe --tags --abbrev=0 | grep -E "$PREFIX" | sed -e "s/^$PREFIX//")
+# Since grep will return 1 if no match, we test for that and if matches will return 0 instead.
+# Any other error code will exit as error (ie: 2).
+LAST_TAG=$(git describe --tags --abbrev=0 | grep -E "$PREFIX" | { grep -v grep || test $? = 1; } | sed -e "s/^$PREFIX//")
 
 echo "Last Tag: $LAST_TAG"
 echo "Semver part to update: $LABEL"

--- a/src/scripts/export-tag.sh
+++ b/src/scripts/export-tag.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 COMMIT_SHA=$(eval echo "$SHA")
 echo "Commit hash: $COMMIT_SHA"
 NAT='0|[1-9][0-9]*'
@@ -19,6 +21,7 @@ fi
 
 echo "Try to get last tag using prefix: ${PREFIX}. If this is a new prefix, we will start from scratch."
 
+set -x
 LAST_TAG=$(git describe --tags --abbrev=0 | grep -E "$PREFIX" | sed -e "s/^$PREFIX//")
 
 echo "Last Tag: $LAST_TAG"

--- a/src/scripts/export-tag.sh
+++ b/src/scripts/export-tag.sh
@@ -20,7 +20,8 @@ echo "Try to get last tag using prefix: ${PREFIX}. If this is a new prefix, we w
 # Since grep will return 1 if no match, we test for that and if matches will return 0 instead.
 # Any other error code will exit as error (ie: 2). Circleci is running this with -eo pipefail,
 # so we need to add the same test to all our greps :|
-LAST_TAG=$(git describe --tags --abbrev=0 | { grep -E "$PREFIX" || test $? = 1; } | { grep -v grep || test $? = 1; } | sed -e "s/^$PREFIX//")
+#LAST_TAG=$(git describe --tags --abbrev=0 | { grep -E "$PREFIX" || test $? = 1; } | { grep -v grep || test $? = 1; } | sed -e "s/^$PREFIX//")
+LAST_TAG=$(git tag --list --sort=-version:refname "${PREFIX}*" | head -n 1)
 
 echo "Last Tag: $LAST_TAG"
 echo "Semver part to update: $LABEL"

--- a/src/scripts/export-tag.sh
+++ b/src/scripts/export-tag.sh
@@ -70,16 +70,16 @@ function increment {
     patch) new="${major}.${minor}.$((patch + 1))";;
     esac
 
-    echo "$new"
-    echo "export NEW_SEMVER_TAG=${PREFIX}${new}" >> "$BASH_ENV"
+    echo "New Tag: $new"
+    NEW_SEMVER_TAG=${PREFIX}${new}
+    echo "export NEW_SEMVER_TAG=$NEW_SEMVER_TAG" >> "$BASH_ENV"
 
-    if [ -z "$NEW_SEMVER_TAG" ]
-    then
-          echo "\$NEW_SEMVER_TAG is empty. Exiting!"
-          exit 1
+    if [ -z "$NEW_SEMVER_TAG" ]; then
+        echo "\$NEW_SEMVER_TAG is empty. Exiting!"
+        exit 1
     else
-          echo "\$NEW_SEMVER_TAG is: ${NEW_SEMVER_TAG}"
-          exit 0
+        echo "\$NEW_SEMVER_TAG is: ${NEW_SEMVER_TAG}"
+        exit 0
     fi
 }
 

--- a/src/scripts/export-tag.sh
+++ b/src/scripts/export-tag.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 COMMIT_SHA=$(eval echo "$SHA")
 echo "Commit hash: $COMMIT_SHA"
 NAT='0|[1-9][0-9]*'
@@ -20,8 +18,9 @@ fi
 
 echo "Try to get last tag using prefix: ${PREFIX}. If this is a new prefix, we will start from scratch."
 # Since grep will return 1 if no match, we test for that and if matches will return 0 instead.
-# Any other error code will exit as error (ie: 2).
-LAST_TAG=$(git describe --tags --abbrev=0 | grep -E "$PREFIX" | { grep -v grep || test $? = 1; } | sed -e "s/^$PREFIX//")
+# Any other error code will exit as error (ie: 2). Circleci is running this with -eo pipefail,
+# so we need to add the same test to all our greps :|
+LAST_TAG=$(git describe --tags --abbrev=0 | { grep -E "$PREFIX" || test $? = 1; } | { grep -v grep || test $? = 1; } | sed -e "s/^$PREFIX//")
 
 echo "Last Tag: $LAST_TAG"
 echo "Semver part to update: $LABEL"


### PR DESCRIPTION
When using this in a project with different releases prefixes (ie: `build-v` and `rc-x`), we should get the last created tag that matches the prefix set in the command.

Example call for the export command:
```yaml
            - pr-semver/export-tag:
                git-username: "the_user_name"
                tag-prefix: "build-v"
```

So I'm replacing here the `git describe --tags --abbrev=0` with `git tag --list --sort=-version:refname "${PREFIX}*" | head -n 1`